### PR TITLE
Replace OpenTracing error logs with SignalFx tags

### DIFF
--- a/requests_opentracing/tracing.py
+++ b/requests_opentracing/tracing.py
@@ -35,9 +35,12 @@ class SessionTracing(requests.sessions.Session):
             try:
                 resp = super(SessionTracing, self).request(method, url, *args, **kwargs)
                 span.set_tag(tags.HTTP_STATUS_CODE, resp.status_code)
-            except Exception:
+            except Exception as exc:
                 span.set_tag(tags.ERROR, True)
-                span.set_tag('error.object', format_exc())
+                span.set_tag('sfx.error.kind', exc.__class__.__name__)
+                span.set_tag('sfx.error.object', str(exc.__class__))
+                span.set_tag('sfx.error.message', str(exc))
+                span.set_tag('sfx.error.stack', format_exc())
                 raise
 
         return resp

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open(os.path.join(cwd, 'README.rst')) as readme_file:
     long_description = readme_file.read()
 
 # Keep these separated for tox extras
-test_requirements = ['mock', 'pytest']
+test_requirements = ['mock', 'pytest', 'packaging']
 integration_test_requirements = ['docker']
 
 setup(


### PR DESCRIPTION
This PR changes how errors are recorded on spans. It uses the new
SignalFx semantic convention and records the errors as attributes
instead of logs.